### PR TITLE
Signups management improved.

### DIFF
--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -138,7 +138,7 @@ class UsersController < ApplicationController
     @user.password_reset = no_password_reset_needed ? false : true
 
     if @user.save
-      flash[:notice] = "User successfully created."
+      flash[:notice] = "User successfully created.\n"
 
       # Find signup record matching login name, and log creation and transfer some info.
       if signup = Signup.where(:id => params[:signup_id]).first
@@ -158,7 +158,7 @@ class UsersController < ApplicationController
         flash[:notice] += "Since this user has no proper email address, no welcome email was sent."
       else
         if send_welcome_email(@user, params[:user][:password], no_password_reset_needed)
-          flash[:notice] += "\nA welcome email is being sent to '#{@user.email}'."
+          flash[:notice] += "A welcome email is being sent to '#{@user.email}'."
         else
           flash[:error] = "Could not send email to '#{@user.email}' informing them that their account was created."
         end

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -37,6 +37,8 @@ class Signup < ActiveRecord::Base
 
   validate              :login_match_user_format
 
+  belongs_to            :user
+
   def strip_blanks #:nodoc:
     [
       :title, :first, :middle, :last,
@@ -76,11 +78,11 @@ class Signup < ActiveRecord::Base
   end
 
   def dup_email? #:nodoc:
-    User.exists?(:email => self.email)
+    User.where(:email => self.email).exists?
   end
 
   def dup_login? #:nodoc:
-    !self.approved? && User.exists?(:login => self.login)
+    !self.approved? && User.where(:login => self.login).exists?
   end
 
   # Returns a new NormalUser (not saved in the DB yet) based

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -97,6 +97,7 @@ class User < ActiveRecord::Base
   has_and_belongs_to_many :access_profiles
   has_and_belongs_to_many :groups
   belongs_to              :site
+  has_one                 :signup
 
   # The following resources are destroyed automatically when the user is destroyed.
   has_many                :messages,        :dependent => :destroy

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -25,21 +25,22 @@
 <%= form_tag( { :action => :multi_action }, :method => :post) do %>
 
   <div class="menu-bar">
-    <%= link_to "New Request", { :action => :new }, { :class => "button menu_button" }  %>
+    <%= link_to "New Request", new_signup_path, :class => "button" %>
+
     <%
        # Careful, the labels of the buttons below are used by the controller
        # to select which multi action to perform. Change them at both places.
     %>
+
     <%= submit_tag "Delete",                :class => "button" %>
     <%= submit_tag "Adjust Login",          :class => "button" %>
     <%= submit_tag "Resend Confirm Email",  :class => "button" %>
+    <%= submit_tag "Toggle Hidden",         :class => "button" %>
 
     <% if @scope.custom[:view_hidden] %>
-      <%= submit_tag "Show", :class => "button" %>
-      <%= link_to "Hide Hidden", { :action => :index, :params => {:view_hidden => false} }, :class => "button" %>
+      <%= link_to "Hide Hidden Records", signups_path(:view_hidden => false), :class => "button" %>
     <% else %>
-      <%= submit_tag "Hide", :class => "button" %>
-      <%= link_to "Show Hidden", { :action => :index, :params => {:view_hidden => true} }, :class => "button" %>
+      <%= link_to "Show All Records",    signups_path(:view_hidden => true),  :class => "button" %>
     <% end %>
   </div>
 
@@ -84,13 +85,13 @@
     <%
       t.column("Name", :last,
         :sortable => true
-      ) { |d| link_to d.full, :action => :show, :id => d.id }
+      ) { |d| link_to d.full, signup_path(d) }
     %>
 
     <%
       t.column("Edit", :edit) do |d|
     %>
-      <%= link_to "Edit", :action => :edit, :id => d.id %>
+      <%= link_to "Edit", edit_signup_path(d), :class => 'action_link' %>
     <% end %>
 
     <%
@@ -164,36 +165,18 @@
 
     <%
       t.column("Created", :created_at,
-        :sortable => true,
-        :sort_order => :desc) do |d|
-
-        to_localtime(d.created_at, :datetime)
+        :sortable => true
+      ) do |d|
+        html_tool_tip(to_localtime(d.created_at, :datetime), :offset_x => 0, :offset_y => 20) do
+          "Updated: #{d.updated_at.in_time_zone.strftime("%a %b %d, %Y at %H:%M:%S %Z")}".html_safe
+        end
       end
     %>
 
     <%
       t.column("Status", :status) do |d|
     %>
-      <% if d[:hidden] %>
-        <%= hidden_icon %>
-      <% end %>
-      <% if d.approved? %>
-        Approved by <%= d.approved_by %> at <%= d.approved_at %>
-      <% else %>
-        <% if d.confirmed? %>
-          <span><strong>Email confirmed.</strong></span>
-        <% else %>
-          <span class="warning">(Email unconfirmed)</span>
-        <% end %>
-        <% if d.dup_email? and not d.approved? %>
-          <span  class="warning">(Conflicting email)</span>
-        <% end %>
-        <% if d.dup_login? %>
-          <span class="warning">(Login conflict)</span>
-        <% else %>
-          <%= link_to "(Approve)", new_user_path(:signup_id => d.id), :class => 'action_link' %>
-        <% end %>
-      <% end %>
+      <%= render :partial => 'status', :locals => { :signup => d, :multi_lines => false } %>
     <% end %>
 
   <% end %>

--- a/BrainPortal/app/views/signups/_status.html.erb
+++ b/BrainPortal/app/views/signups/_status.html.erb
@@ -1,0 +1,60 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<%
+#
+# Partial with these locals:
+#
+# signup          : signup object
+# multi_lines     : if true each status info separated by a BR
+#
+%>
+
+<% newline = (multi_lines.present? rescue false) ? "<br>".html_safe : "" %>
+
+<%= hidden_icon if signup.hidden? %>
+
+<% if signup.approved? %>
+  Approved by <%= signup.approved_by %> at <%= signup.approved_at %>
+<% else %>
+
+  <% if signup.confirmed? %>
+    <span><strong>Email confirmed.</strong></span>
+  <% else %>
+    <span class="warning">(Email unconfirmed)</span>
+  <% end %>
+  <%= newline %>
+
+  <% if signup.dup_email? %>
+    <span class="warning">(Conflicting email)</span><%= newline %>
+  <% end %>
+
+  <% if signup.dup_login? %>
+    <span class="warning">(Login conflict)</span>
+  <% else %>
+    <%= link_to "(Approve)", new_user_path(:signup_id => signup.id), :class => 'action_link' %>
+  <% end %>
+
+<% end %>
+

--- a/BrainPortal/app/views/signups/new.html.erb
+++ b/BrainPortal/app/views/signups/new.html.erb
@@ -152,13 +152,16 @@
       </td>
     </tr>
 
-    <% if @current_user.present? && current_user.has_role?(:admin_user) %>
+    <% if current_user.present? && current_user.has_role?(:admin_user) %>
+      <tr>
+        <td colspan="2">&nbsp;</td>
+      </tr>
+
       <tr>
         <th> <%= f.label(:admin_comment, "Private, admin-only comments:") %> </th>
         <td> <%= f.text_area :admin_comment, :cols=>80, :rows => 5 %> </td>
       </tr>
     <% end %>
-
 
     <tr>
       <td colspan="2">&nbsp;</td>

--- a/BrainPortal/app/views/signups/show.html.erb
+++ b/BrainPortal/app/views/signups/show.html.erb
@@ -88,6 +88,16 @@ Below is a summary of the information in this account request.
   </tr>
 
   <tr>
+    <th>Prefered 'login' name:</th>
+    <td><%= @signup.login.presence || "(none)" %></td>
+  </tr>
+
+  <tr>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
     <th>Name of Institution/Organization:</th>
     <td><%= @signup.institution %></td>
   </tr>
@@ -105,6 +115,11 @@ Below is a summary of the information in this account request.
   <tr>
     <th>Email address:</th>
     <td><%= @signup.email %></td>
+  </tr>
+
+  <tr>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
   </tr>
 
   <tr>
@@ -138,13 +153,8 @@ Below is a summary of the information in this account request.
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <th>Prefered 'login' name:</th>
-    <td><%= @signup.login.presence || "(none)" %></td>
+    <th>Time Zone:</th>
+    <td><%= @signup.time_zone %></td>
   </tr>
 
   <tr>
@@ -154,38 +164,36 @@ Below is a summary of the information in this account request.
 
   <% if @signup.comment.present? %>
 
-  <tr>
-    <th>Comments or special requests:</th>
-    <td><%= @signup.comment %></td>
-  </tr>
+    <tr>
+      <th>Comments or special requests:</th>
+      <td><pre><%= @signup.comment %></pre></td>
+    </tr>
 
-  <tr>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-  </tr>
+    <tr>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
 
-  <% if @current_user.present? && @current_user.has_role?(:admin_user) %>
+  <% end %>
+
+  <% if current_user.present? && current_user.has_role?(:admin_user) %>
+
     <tr>
       <th>Admin Comments</th>
-      <td> <pre><%= @signup.admin_comment %></pre> </td>
+      <td><pre><%= @signup.admin_comment %></pre></td>
     </tr>
-  <% end %>
+
+    <tr>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
 
   <% end %>
 
   <tr>
     <th>Status of request:</th>
     <td>
-      <% if @signup.confirmed? %>
-        Email address confirmed by user.<br>
-      <% else %>
-        <span class="warning">Email address not yet confirmed.</span><br>
-      <% end %>
-      <% if @signup.approved? %>
-        Request approved by administrator.
-      <% else %>
-        <span class="warning">Request not yet approved by administrator.</span>
-      <% end %>
+      <%= render :partial => 'status', :locals => { :signup => @signup, :multi_lines => true } %>
     </td>
   </tr>
 

--- a/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
+++ b/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
@@ -5,11 +5,14 @@ class SignupsTweaks < ActiveRecord::Migration
     add_column    :signups, :user_id, :integer
     add_column    :signups, :hidden, :boolean, :default => false
 
-    Signup.all.each do |d|
-      if user = User.where(:login => d.login).first
-        d[:user_id] = user.id
-        d.save
-      end
+    Signup.where(:user_id => nil).all
+      .select { |d| d.login.present? && d.approved? }
+      .each do |d|
+        if user = User.where(:login => d.login).first
+          puts "Adjusting link: Signup ##{d.id} #{d.full} created user: #{user.login}"
+          d.user_id = user.id
+          d.save
+        end
     end
   end
 


### PR DESCRIPTION
Numerous improvements.

* use proper path builders in controller
* the show/hide hidden button now sets the state in the session and it sticks around
* a single button is used to toggle hidden vs shown
* proper active record associations are created between models (has_one, belongs_to)
* sorting by creation date now works
* creation dates in index page have tooltip with update dates
* status of signup extracted into a partial view, used by index and show
* layouts of show and edit page improved
* migration now checks to update only the proper records; prints messages